### PR TITLE
Follow upstream to SETUP-MACPORTS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: macos-11
     steps:
-    - uses: melusina-org/gha-install-macports@v1
+    - uses: melusina-org/setup-macports@v1
     #- name: Install MacPorts
     #  run: |
     #    curl -LO https://raw.githubusercontent.com/tuffnatty/macports-ci/hash-r-after-homebrew-removal/macports-ci


### PR DESCRIPTION
I'm about to archive gha-install-macports and continue work in setup-macports, so you might want to use that as well.

BTW macos-11 and macos-12 are also supported.